### PR TITLE
Fix: make macOS build self-contained (static GLM, bundled MoltenVK)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Package macOS
         run: |
-          strip -x build/fvd.app/Contents/MacOS/fvd
-          codesign --force --deep --sign - build/fvd.app
-          ditto -c -k --keepParent build/fvd.app fvd-macos-arm64.zip
+          strip -x "build/FVD++.app/Contents/MacOS/FVD++"
+          codesign --force --deep --sign - "build/FVD++.app"
+          ditto -c -k --keepParent "build/FVD++.app" fvd-macos-arm64.zip
 
       - name: Upload macOS Artifact
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,9 @@ target_include_directories(fvd PRIVATE
     ${imgui_SOURCE_DIR}/backends
     ${implot_SOURCE_DIR}
 )
-if(TARGET glm::glm)
+if(TARGET glm::glm-header-only)
+    target_link_libraries(fvd PRIVATE glm::glm-header-only)
+elseif(TARGET glm::glm)
     target_link_libraries(fvd PRIVATE glm::glm)
 endif()
 
@@ -185,20 +187,26 @@ if(UNIX AND NOT APPLE)
     target_link_options(fvd PRIVATE -rdynamic)
 elseif(APPLE)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
+    find_library(MOLTENVK_LIBRARY NAMES MoltenVK
+        HINTS /opt/homebrew/opt/molten-vk/lib /usr/local/opt/molten-vk/lib REQUIRED)
     target_link_libraries(fvd PRIVATE
         glfw
         imgui
         implot
-        Vulkan::Vulkan
+        ${MOLTENVK_LIBRARY}
         ${COREFOUNDATION_LIBRARY}
     )
+    target_include_directories(fvd PRIVATE ${Vulkan_INCLUDE_DIRS})
     set_target_properties(fvd PROPERTIES
+        OUTPUT_NAME "FVD++"
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_BUNDLE_NAME "FVD++"
         MACOSX_BUNDLE_GUI_IDENTIFIER "org.openfvd.fvdplusplus"
         MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/Info.plist.in
+        BUILD_RPATH "@loader_path/../Frameworks"
+        INSTALL_RPATH "@loader_path/../Frameworks"
     )
     add_custom_command(TARGET fvd POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -210,7 +218,18 @@ elseif(APPLE)
         COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_SOURCE_DIR}/icons/fvd_orig.icns
             $<TARGET_BUNDLE_CONTENT_DIR:fvd>/Resources/fvd.icns
-        COMMENT "Bundling track styles, shaders and icon"
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            $<TARGET_BUNDLE_CONTENT_DIR:fvd>/Frameworks
+        COMMAND ${CMAKE_COMMAND} -E copy ${MOLTENVK_LIBRARY}
+            $<TARGET_BUNDLE_CONTENT_DIR:fvd>/Frameworks/libMoltenVK.dylib
+        COMMAND install_name_tool -id @rpath/libMoltenVK.dylib
+            $<TARGET_BUNDLE_CONTENT_DIR:fvd>/Frameworks/libMoltenVK.dylib
+        COMMAND install_name_tool -change ${MOLTENVK_LIBRARY} @rpath/libMoltenVK.dylib
+            $<TARGET_FILE:fvd>
+        COMMAND codesign --force --sign -
+            $<TARGET_BUNDLE_CONTENT_DIR:fvd>/Frameworks/libMoltenVK.dylib
+        COMMAND codesign --force --sign - $<TARGET_BUNDLE_DIR:fvd>
+        COMMENT "Bundling track styles, shaders, icon and MoltenVK"
     )
 elseif(WIN32)
     target_link_libraries(fvd PRIVATE


### PR DESCRIPTION
Makes the macOS app self-contained so it runs without a Homebrew setup. Right now it crashes on launch with `Library not loaded: .../libglm.dylib`.

- link GLM header-only instead of the shared libglm.dylib
- bundle MoltenVK into the app, no vulkan-loader/molten-vk needed at runtime
- re-sign after install_name_tool, otherwise dyld rejects it on Apple Silicon
- bundle is now FVD++.app

Windows and Linux unchanged, there the Vulkan loader comes with the driver/distro. Tested on an M2 Pro, otool shows only system frameworks plus the bundled MoltenVK.